### PR TITLE
#15 - Make options on adalFetch optional

### DIFF
--- a/src/react-adal.js
+++ b/src/react-adal.js
@@ -31,7 +31,7 @@ export function runWithAdal(authContext, app) {
 
 export function adalFetch(authContext, resourceGuiId, fetch, url, options) {
   return adalGetToken(authContext, resourceGuiId).then((token) => {
-    const o = options;
+    const o = options || {};
     if (!o.headers) o.headers = {};
     o.headers.Authorization = `Bearer ${token}`;
     return fetch(url, options);


### PR DESCRIPTION
This change makes the options parameter of the adalFetch function optional. This behavior matches up with that of the underlying JS fetch API in which the equivalent parameter is also optional.