### PR TITLE
Bug fix in adalFetch

### DIFF
--- a/src/react-adal.js
+++ b/src/react-adal.js
@@ -40,7 +40,7 @@ export function adalFetch(authContext, resourceGuiId, fetch, url, options) {
     const o = options || {};
     if (!o.headers) o.headers = {};
     o.headers.Authorization = `Bearer ${token}`;
-    return fetch(url, options);
+    return fetch(url, o);
   });
 }
 


### PR DESCRIPTION
adalFetch fails to populate and return the options object when no initial options object is passed in.