### PR TITLE
Add MFA support

### DIFF
--- a/src/react-adal.js
+++ b/src/react-adal.js
@@ -4,10 +4,12 @@ import AuthenticationContext_ from './adal';
 
 export const AuthenticationContext = AuthenticationContext_;
 
-export function adalGetToken(authContext, resourceGuiId) {
+export function adalGetToken(authContext, resourceGuiId, callback) {
   return new Promise((resolve, reject) => {
     authContext.acquireToken(resourceGuiId, (message, token, msg) => {
       if (!msg) resolve(token);
+      // Default to redirect for multi-factor authentication, but allow using popup if a callback is provided
+      else if (message.includes('AADSTS50076') || message.includes('AADSTS50079')) callback ? authContext.acquireTokenPopup(resourceGuiId, callback) : authContext.acquireTokenRedirect(resourceGuiId);
       // eslint-disable-next-line
       else reject({ message, msg });
     });


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/azure/active-directory/develop/conditional-access-dev-guide, MFA is required on some accounts by returning the error codes AADSTS50076 or AADSTS50079. This change checks the error message for those codes, and if present, continues the MFA flow by either redirecting for interactive login, or using a popup if a callback is provided.

Addresses issue #39