### PR TITLE
Add display: 'none' on iframe

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -1659,6 +1659,7 @@ var _AuthenticationContext = function () {
                 var ifr = document.createElement('iframe');
                 ifr.setAttribute('id', iframeId);
                 ifr.setAttribute('aria-hidden', 'true');
+                ifr.style.display = 'none';
                 ifr.style.visibility = 'hidden';
                 ifr.style.position = 'absolute';
                 ifr.style.width = ifr.style.height = ifr.borderWidth = '0px';

--- a/src/adal.js
+++ b/src/adal.js
@@ -1683,6 +1683,7 @@ var AuthenticationContext = (function () {
                 var ifr = document.createElement('iframe');
                 ifr.setAttribute('id', iframeId);
                 ifr.setAttribute('aria-hidden', 'true');
+                ifr.style.display = 'none';
                 ifr.style.visibility = 'hidden';
                 ifr.style.position = 'absolute';
                 ifr.style.width = ifr.style.height = ifr.borderWidth = '0px';


### PR DESCRIPTION
An issue with the iframe is that it appears as 4x4 px frame, which is a big issue for sites with 100% height as this causes an overflow. Setting display: none resolves this issue.