### PR TITLE
Fixes IE compatibility

### DIFF
--- a/src/react-adal.js
+++ b/src/react-adal.js
@@ -11,7 +11,7 @@ const redirectMessages = [
 ];
 
 function shouldAcquireNewToken(message) {
-  return redirectMessages.reduce((a, v) => a || message.includes(v), false);
+  return redirectMessages.some((v)=>(message.indexOf(v)!==-1));
 }
 
 export function adalGetToken(authContext, resourceGuiId, callback) {


### PR DESCRIPTION
This fixes IE compatibility because [String.prototype.includes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes) isn't implemented in IE.

As a bonus, it's a little more efficient (because it's using `some`). In case the `redirectMessages` array grows.