### PR TITLE
Update SDK + allow extra parameters

### DIFF
--- a/internals/update-sdk.js
+++ b/internals/update-sdk.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-console */
+const { createWriteStream } = require('fs');
+const https = require('https');
+
+const SDK_FILE = `${process.cwd()}/src/adal.js`;
+const SDK_SOURCE_URL = 'https://raw.githubusercontent.com/AzureAD/azure-activedirectory-library-for-js/dev/lib/adal.js';
+
+const fileStream = createWriteStream(SDK_FILE, { defaultEncoding: 'utf8' });
+
+const terminateWithSuccess = () => {
+  console.log('SDK SUCCESSFULLY UPDATED');
+  process.exit(0);
+};
+
+const terminateWithFailure = (err) => {
+  console.error('ERROR WHILE UPDATING SDK');
+  console.error(err);
+  process.exit(0);
+};
+
+
+console.log(`DOWNLOADING FROM ${SDK_SOURCE_URL}`);
+
+https.get(
+  SDK_SOURCE_URL,
+  res => (res.statusCode === 200
+    ? res.on('end', terminateWithSuccess).pipe(fileStream)
+    : terminateWithFailure(new Error(`Failed downloading SDK from ${SDK_SOURCE_URL}, status: ${res.statusCode}`))),
+).on('error', terminateWithFailure);

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -3,7 +3,7 @@
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 //----------------------------------------------------------------------
-// AdalJS v1.0.17
+// AdalJS v1.0.18
 // @preserve Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
 // Apache License 2.0
@@ -133,7 +133,11 @@ var _AuthenticationContext = function () {
     this._callBacksMappedToRenewStates = {};
     this._openedWindows = [];
     this._requestType = this.REQUEST_TYPE.LOGIN;
-    window._adalInstance = this; // validate before constructor assignments
+    window._adalInstance = this;
+    this._storageSupport = {
+      localStorage: null,
+      sessionStorage: null
+    }; // validate before constructor assignments
 
     if (config.displayCall && typeof config.displayCall !== 'function') {
       throw new Error('displayCall is not a function');
@@ -255,15 +259,15 @@ var _AuthenticationContext = function () {
   _AuthenticationContext.prototype._openPopup = function (urlNavigate, title, popUpWidth, popUpHeight) {
     try {
       /**
-       * adding winLeft and winTop to account for dual monitor
-       * using screenLeft and screenTop for IE8 and earlier
-       */
+      * adding winLeft and winTop to account for dual monitor
+      * using screenLeft and screenTop for IE8 and earlier
+      */
       var winLeft = window.screenLeft ? window.screenLeft : window.screenX;
       var winTop = window.screenTop ? window.screenTop : window.screenY;
       /**
-       * window.innerWidth displays browser window's height and width excluding toolbars
-       * using document.documentElement.clientWidth for IE8 and earlier
-       */
+      * window.innerWidth displays browser window's height and width excluding toolbars
+      * using document.documentElement.clientWidth for IE8 and earlier
+      */
 
       var width = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
       var height = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight;
@@ -444,11 +448,11 @@ var _AuthenticationContext = function () {
     }
   };
   /**
-   * User information from idtoken.
-   *  @class User
-   *  @property {string} userName - username assigned from upn or email.
-   *  @property {object} profile - properties parsed from idtoken.
-   */
+  * User information from idtoken.
+  *  @class User
+  *  @property {string} userName - username assigned from upn or email.
+  *  @property {object} profile - properties parsed from idtoken.
+  */
 
   /**
    * If user object exists, returns it. Else creates a new user object by decoding id_token from the cache.
@@ -467,7 +471,7 @@ var _AuthenticationContext = function () {
     return this._user;
   };
   /**
-   * Adds the passed callback to the array of callbacks for the specified resource and puts the array on the window object.
+   * Adds the passed callback to the array of callbacks for the specified resource and puts the array on the window object. 
    * @param {string}   resource A URI that identifies the resource for which the token is requested.
    * @param {string}   expectedState A unique identifier (guid).
    * @param {tokenCallback} callback - The callback provided by the caller. It will be called with token or error.
@@ -734,11 +738,11 @@ var _AuthenticationContext = function () {
     }
   };
   /**
-   * Acquires token (interactive flow using a popUp window) by sending request to AAD to obtain a new token.
-   * @param {string}   resource  ResourceUri identifying the target resource
-   * @param {string}   extraQueryParameters  extraQueryParameters to add to the authentication request
-   * @param {tokenCallback} callback -  The callback provided by the caller. It will be called with token or error.
-   */
+  * Acquires token (interactive flow using a popUp window) by sending request to AAD to obtain a new token.
+  * @param {string}   resource  ResourceUri identifying the target resource
+  * @param {string}   extraQueryParameters  extraQueryParameters to add to the authentication request
+  * @param {tokenCallback} callback -  The callback provided by the caller. It will be called with token or error.
+  */
 
 
   _AuthenticationContext.prototype.acquireTokenPopup = function (resource, extraQueryParameters, claims, callback) {
@@ -790,11 +794,11 @@ var _AuthenticationContext = function () {
     this._loginPopup(urlNavigate, resource, callback);
   };
   /**
-   * Acquires token (interactive flow using a redirect) by sending request to AAD to obtain a new token. In this case the callback passed in the Authentication
-   * request constructor will be called.
-   * @param {string}   resource  ResourceUri identifying the target resource
-   * @param {string}   extraQueryParameters  extraQueryParameters to add to the authentication request
-   */
+    * Acquires token (interactive flow using a redirect) by sending request to AAD to obtain a new token. In this case the callback passed in the Authentication
+    * request constructor will be called.
+    * @param {string}   resource  ResourceUri identifying the target resource
+    * @param {string}   extraQueryParameters  extraQueryParameters to add to the authentication request
+    */
 
 
   _AuthenticationContext.prototype.acquireTokenRedirect = function (resource, extraQueryParameters, claims) {
@@ -866,6 +870,8 @@ var _AuthenticationContext = function () {
 
 
   _AuthenticationContext.prototype.clearCache = function () {
+    this._user = null;
+
     this._saveItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST, '');
 
     this._saveItem(this.CONSTANTS.STORAGE.ANGULAR_LOGIN_REQUEST, '');
@@ -931,7 +937,6 @@ var _AuthenticationContext = function () {
 
   _AuthenticationContext.prototype.logOut = function () {
     this.clearCache();
-    this._user = null;
     var urlNavigate;
 
     if (this.config.logOutUri) {
@@ -1002,7 +1007,7 @@ var _AuthenticationContext = function () {
 
 
   _AuthenticationContext.prototype._addHintParameters = function (urlNavigate) {
-    //If you don�t use prompt=none, then if the session does not exist, there will be a failure.
+    //If you don't use prompt=none, then if the session does not exist, there will be a failure.
     //If sid is sent alongside domain or login hints, there will be a failure since request is ambiguous.
     //If sid is sent with a prompt value other than none or attempt_none, there will be a failure since the request is ambiguous.
     if (this._user && this._user.profile) {
@@ -1170,9 +1175,9 @@ var _AuthenticationContext = function () {
     return requestInfo;
   };
   /**
-   * Matches nonce from the request with the response.
-   * @ignore
-   */
+  * Matches nonce from the request with the response.
+  * @ignore
+  */
 
 
   _AuthenticationContext.prototype._matchNonce = function (user) {
@@ -1191,9 +1196,9 @@ var _AuthenticationContext = function () {
     return false;
   };
   /**
-   * Matches state from the request with the response.
-   * @ignore
-   */
+  * Matches state from the request with the response.
+  * @ignore
+  */
 
 
   _AuthenticationContext.prototype._matchState = function (requestInfo) {
@@ -1312,17 +1317,17 @@ var _AuthenticationContext = function () {
               this._saveItem(this.CONSTANTS.STORAGE.IDTOKEN, requestInfo.parameters[this.CONSTANTS.ID_TOKEN]); // Save idtoken as access token for app itself
 
 
-              resource = this.config.loginResource ? this.config.loginResource : this.config.clientId;
+              var idTokenResource = this.config.loginResource ? this.config.loginResource : this.config.clientId;
 
-              if (!this._hasResource(resource)) {
+              if (!this._hasResource(idTokenResource)) {
                 keys = this._getItem(this.CONSTANTS.STORAGE.TOKEN_KEYS) || '';
 
-                this._saveItem(this.CONSTANTS.STORAGE.TOKEN_KEYS, keys + resource + this.CONSTANTS.RESOURCE_DELIMETER);
+                this._saveItem(this.CONSTANTS.STORAGE.TOKEN_KEYS, keys + idTokenResource + this.CONSTANTS.RESOURCE_DELIMETER);
               }
 
-              this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + resource, requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
+              this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + idTokenResource, requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
 
-              this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + resource, this._user.profile.exp);
+              this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + idTokenResource, this._user.profile.exp);
             }
           } else {
             requestInfo.parameters['error'] = 'invalid id_token';
@@ -1380,7 +1385,7 @@ var _AuthenticationContext = function () {
       }
     } else {
       // in angular level, the url for $http interceptor call could be relative url,
-      // if it's relative call, we'll treat it as app backend call.
+      // if it's relative call, we'll treat it as app backend call.            
       return this.config.loginResource;
     } // if not the app's own backend or not a domain listed in the endpoints structure
 
@@ -1534,7 +1539,7 @@ var _AuthenticationContext = function () {
     } else {
       return decodeURIComponent(escape(this._decode(base64IdToken)));
     }
-  }; //Take https://cdnjs.cloudflare.com/ajax/libs/Base64/0.3.0/base64.js and https://en.wikipedia.org/wiki/Base64 as reference.
+  }; //Take https://cdnjs.cloudflare.com/ajax/libs/Base64/0.3.0/base64.js and https://en.wikipedia.org/wiki/Base64 as reference. 
 
 
   _AuthenticationContext.prototype._decode = function (base64IdToken) {
@@ -1816,7 +1821,7 @@ var _AuthenticationContext = function () {
         ifr.setAttribute('aria-hidden', 'true');
         ifr.style.visibility = 'hidden';
         ifr.style.position = 'absolute';
-        ifr.style.width = ifr.style.height = ifr.borderWidth = '0px';
+        ifr.style.width = ifr.style.height = ifr.style.borderWidth = '0px';
         adalFrame = document.getElementsByTagName('body')[0].appendChild(ifr);
       } else if (document.body && document.body.insertAdjacentHTML) {
         document.body.insertAdjacentHTML('beforeEnd', '<iframe name="' + iframeId + '" id="' + iframeId + '" style="display:none"></iframe>');
@@ -1886,27 +1891,53 @@ var _AuthenticationContext = function () {
     return sessionStorage.getItem(key);
   };
   /**
+   * Returns true if the browser supports given storage type
+   * @ignore
+   */
+
+
+  _AuthenticationContext.prototype._supportsStorage = function (storageType) {
+    if (!(storageType in this._storageSupport)) {
+      return false;
+    }
+
+    if (this._storageSupport[storageType] !== null) {
+      return this._storageSupport[storageType];
+    }
+
+    try {
+      if (!(storageType in window) || window[storageType] === null) {
+        throw new Error();
+      }
+
+      var testKey = '__storageTest__';
+      window[storageType].setItem(testKey, 'A');
+
+      if (window[storageType].getItem(testKey) !== 'A') {
+        throw new Error();
+      }
+
+      window[storageType].removeItem(testKey);
+
+      if (window[storageType].getItem(testKey)) {
+        throw new Error();
+      }
+
+      this._storageSupport[storageType] = true;
+    } catch (e) {
+      this._storageSupport[storageType] = false;
+    }
+
+    return this._storageSupport[storageType];
+  };
+  /**
    * Returns true if browser supports localStorage, false otherwise.
    * @ignore
    */
 
 
   _AuthenticationContext.prototype._supportsLocalStorage = function () {
-    try {
-      if (!window.localStorage) return false; // Test availability
-
-      window.localStorage.setItem('storageTest', 'A'); // Try write
-
-      if (window.localStorage.getItem('storageTest') != 'A') return false; // Test read/write
-
-      window.localStorage.removeItem('storageTest'); // Try delete
-
-      if (window.localStorage.getItem('storageTest')) return false; // Test delete
-
-      return true; // Success
-    } catch (e) {
-      return false;
-    }
+    return this._supportsStorage('localStorage');
   };
   /**
    * Returns true if browser supports sessionStorage, false otherwise.
@@ -1915,21 +1946,7 @@ var _AuthenticationContext = function () {
 
 
   _AuthenticationContext.prototype._supportsSessionStorage = function () {
-    try {
-      if (!window.sessionStorage) return false; // Test availability
-
-      window.sessionStorage.setItem('storageTest', 'A'); // Try write
-
-      if (window.sessionStorage.getItem('storageTest') != 'A') return false; // Test read/write
-
-      window.sessionStorage.removeItem('storageTest'); // Try delete
-
-      if (window.sessionStorage.getItem('storageTest')) return false; // Test delete
-
-      return true; // Success
-    } catch (e) {
-      return false;
-    }
+    return this._supportsStorage('sessionStorage');
   };
   /**
    * Returns a cloned copy of the passed object.
@@ -1964,7 +1981,7 @@ var _AuthenticationContext = function () {
     return '&x-client-SKU=Js&x-client-Ver=' + this._libVersion();
   };
   /**
-   * Checks the Logging Level, constructs the Log message and logs it. Users need to implement/override this method to turn on Logging.
+   * Checks the Logging Level, constructs the Log message and logs it. Users need to implement/override this method to turn on Logging. 
    * @param {number} level  -  Level can be set 0,1,2 and 3 which turns on 'error', 'warning', 'info' or 'verbose' level logging respectively.
    * @param {string} message  -  Message to log.
    * @param {string} error  -  Error to log.
@@ -2023,10 +2040,10 @@ var _AuthenticationContext = function () {
     this.log(this.CONSTANTS.LOGGING_LEVEL.VERBOSE, message, null);
   };
   /**
-   * Logs Pii messages when Logging Level is set to 0 and window.piiLoggingEnabled is set to true.
-   * @param {string} message  -  Message to log.
-   * @param {string} error  -  Error to log.
-   */
+  * Logs Pii messages when Logging Level is set to 0 and window.piiLoggingEnabled is set to true.
+  * @param {string} message  -  Message to log.
+  * @param {string} error  -  Error to log.
+  */
 
 
   _AuthenticationContext.prototype.errorPii = function (message, error) {
@@ -2066,7 +2083,7 @@ var _AuthenticationContext = function () {
 
 
   _AuthenticationContext.prototype._libVersion = function () {
-    return '1.0.17';
+    return '1.0.18';
   };
   /**
    * Returns a reference of Authentication Context as a result of a require call.

--- a/lib/react-adal.js
+++ b/lib/react-adal.js
@@ -40,7 +40,8 @@ var AuthenticationContext = isSSR ? function () {} : _adal["default"];
 exports.AuthenticationContext = AuthenticationContext;
 var redirectMessages = ['AADSTS16002', // old sid - https://github.com/salvoravida/react-adal/issues/46
 'AADSTS50076', // MFA support - https://github.com/salvoravida/react-adal/pull/45
-'AADSTS50079'];
+'AADSTS50079' // MFA support
+];
 
 function shouldAcquireNewToken(message) {
   return redirectMessages.some(function (v) {
@@ -48,7 +49,18 @@ function shouldAcquireNewToken(message) {
   });
 }
 
-function adalGetToken(authContext, resourceGuiId, callback) {
+function parseResourceInfo(resourceInfo) {
+  return typeof resourceInfo === 'string' ? {
+    resourceGuiId: resourceInfo
+  } : resourceInfo;
+}
+
+function adalGetToken(authContext, resourceInfo, callback) {
+  var _parseResourceInfo = parseResourceInfo(resourceInfo),
+      resourceGuiId = _parseResourceInfo.resourceGuiId,
+      extraQueryParameters = _parseResourceInfo.extraQueryParameters,
+      claims = _parseResourceInfo.claims;
+
   return new Promise(function (resolve, reject) {
     authContext.acquireToken(resourceGuiId, function (message, token, msg) {
       if (!msg) {
@@ -57,9 +69,9 @@ function adalGetToken(authContext, resourceGuiId, callback) {
         // Default to redirect for multi-factor authentication
         // but allow using popup if a callback is provided
         if (callback) {
-          authContext.acquireTokenPopup(resourceGuiId, callback);
+          authContext.acquireTokenPopup(resourceGuiId, extraQueryParameters, claims, callback);
         } else {
-          authContext.acquireTokenRedirect(resourceGuiId);
+          authContext.acquireTokenRedirect(resourceGuiId, extraQueryParameters, claims);
         }
       } else reject({
         message: message,
@@ -82,7 +94,12 @@ function runWithAdal(authContext, app, doNotLogin) {
 
   if (window === window.parent) {
     if (!authContext.isCallback(window.location.hash)) {
-      if (!authContext.getCachedToken(authContext.config.clientId) || !authContext.getCachedUser()) {
+      var resource = authContext.config.loginResource; // adal sdk assigns clientId if loginResource is not provided
+
+      var token = authContext.getCachedToken(resource);
+      var user = authContext.getCachedUser();
+
+      if (!token || !user) {
         if (doNotLogin) {
           app();
         } else {
@@ -95,8 +112,8 @@ function runWithAdal(authContext, app, doNotLogin) {
   }
 }
 
-function adalFetch(authContext, resourceGuiId, fetch, url, options) {
-  return adalGetToken(authContext, resourceGuiId).then(function (token) {
+function adalFetch(authContext, resourceInfo, fetch, url, options) {
+  return adalGetToken(authContext, resourceInfo).then(function (token) {
     var o = options || {};
     if (!o.headers) o.headers = {};
     o.headers.Authorization = "Bearer ".concat(token);
@@ -105,7 +122,7 @@ function adalFetch(authContext, resourceGuiId, fetch, url, options) {
 } // eslint-disable-next-line
 
 
-var withAdalLogin = function withAdalLogin(authContext, resourceId) {
+var withAdalLogin = function withAdalLogin(authContext, resourceInfo) {
   // eslint-disable-next-line
   return function (WrappedComponent, renderLoading, renderError) {
     var _temp;
@@ -138,7 +155,7 @@ var withAdalLogin = function withAdalLogin(authContext, resourceId) {
           logged: false,
           error: null
         };
-        adalGetToken(authContext, resourceId).then(function () {
+        adalGetToken(authContext, resourceInfo).then(function () {
           if (_this.mounted) {
             _this.setState({
               logged: true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "cross-env NODE_ENV=production babel src --out-dir lib",
     "prepare": "npm run build",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "sdk:update": "node internals/update-sdk.js"
   },
   "repository": {
     "type": "git",

--- a/src/adal.js
+++ b/src/adal.js
@@ -1,5 +1,5 @@
 //----------------------------------------------------------------------
-// AdalJS v1.0.17
+// AdalJS v1.0.18
 // @preserve Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
 // Apache License 2.0
@@ -135,6 +135,10 @@ var AuthenticationContext = (function () {
         this._openedWindows = [];
         this._requestType = this.REQUEST_TYPE.LOGIN;
         window._adalInstance = this;
+        this._storageSupport = {
+            localStorage: null,
+            sessionStorage: null
+        };
 
         // validate before constructor assignments
         if (config.displayCall && typeof config.displayCall !== 'function') {
@@ -252,15 +256,15 @@ var AuthenticationContext = (function () {
     AuthenticationContext.prototype._openPopup = function (urlNavigate, title, popUpWidth, popUpHeight) {
         try {
             /**
-             * adding winLeft and winTop to account for dual monitor
-             * using screenLeft and screenTop for IE8 and earlier
-             */
+            * adding winLeft and winTop to account for dual monitor
+            * using screenLeft and screenTop for IE8 and earlier
+            */
             var winLeft = window.screenLeft ? window.screenLeft : window.screenX;
             var winTop = window.screenTop ? window.screenTop : window.screenY;
             /**
-             * window.innerWidth displays browser window's height and width excluding toolbars
-             * using document.documentElement.clientWidth for IE8 and earlier
-             */
+            * window.innerWidth displays browser window's height and width excluding toolbars
+            * using document.documentElement.clientWidth for IE8 and earlier
+            */
             var width = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
             var height = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight;
             var left = ((width / 2) - (popUpWidth / 2)) + winLeft;
@@ -426,11 +430,11 @@ var AuthenticationContext = (function () {
     };
 
     /**
-     * User information from idtoken.
-     *  @class User
-     *  @property {string} userName - username assigned from upn or email.
-     *  @property {object} profile - properties parsed from idtoken.
-     */
+    * User information from idtoken.
+    *  @class User
+    *  @property {string} userName - username assigned from upn or email.
+    *  @property {object} profile - properties parsed from idtoken.
+    */
 
     /**
      * If user object exists, returns it. Else creates a new user object by decoding id_token from the cache.
@@ -447,7 +451,7 @@ var AuthenticationContext = (function () {
     };
 
     /**
-     * Adds the passed callback to the array of callbacks for the specified resource and puts the array on the window object.
+     * Adds the passed callback to the array of callbacks for the specified resource and puts the array on the window object. 
      * @param {string}   resource A URI that identifies the resource for which the token is requested.
      * @param {string}   expectedState A unique identifier (guid).
      * @param {tokenCallback} callback - The callback provided by the caller. It will be called with token or error.
@@ -688,11 +692,11 @@ var AuthenticationContext = (function () {
     };
 
     /**
-     * Acquires token (interactive flow using a popUp window) by sending request to AAD to obtain a new token.
-     * @param {string}   resource  ResourceUri identifying the target resource
-     * @param {string}   extraQueryParameters  extraQueryParameters to add to the authentication request
-     * @param {tokenCallback} callback -  The callback provided by the caller. It will be called with token or error.
-     */
+  * Acquires token (interactive flow using a popUp window) by sending request to AAD to obtain a new token.
+  * @param {string}   resource  ResourceUri identifying the target resource
+  * @param {string}   extraQueryParameters  extraQueryParameters to add to the authentication request
+  * @param {tokenCallback} callback -  The callback provided by the caller. It will be called with token or error.
+  */
     AuthenticationContext.prototype.acquireTokenPopup = function (resource, extraQueryParameters, claims, callback) {
         if (this._isEmpty(resource)) {
             this.warn('resource is required');
@@ -741,11 +745,11 @@ var AuthenticationContext = (function () {
     };
 
     /**
-     * Acquires token (interactive flow using a redirect) by sending request to AAD to obtain a new token. In this case the callback passed in the Authentication
-     * request constructor will be called.
-     * @param {string}   resource  ResourceUri identifying the target resource
-     * @param {string}   extraQueryParameters  extraQueryParameters to add to the authentication request
-     */
+      * Acquires token (interactive flow using a redirect) by sending request to AAD to obtain a new token. In this case the callback passed in the Authentication
+      * request constructor will be called.
+      * @param {string}   resource  ResourceUri identifying the target resource
+      * @param {string}   extraQueryParameters  extraQueryParameters to add to the authentication request
+      */
     AuthenticationContext.prototype.acquireTokenRedirect = function (resource, extraQueryParameters, claims) {
         if (this._isEmpty(resource)) {
             this.warn('resource is required');
@@ -809,6 +813,7 @@ var AuthenticationContext = (function () {
      * Clears cache items.
      */
     AuthenticationContext.prototype.clearCache = function () {
+        this._user = null;
         this._saveItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST, '');
         this._saveItem(this.CONSTANTS.STORAGE.ANGULAR_LOGIN_REQUEST, '');
         this._saveItem(this.CONSTANTS.STORAGE.SESSION_STATE, '');
@@ -855,7 +860,6 @@ var AuthenticationContext = (function () {
      */
     AuthenticationContext.prototype.logOut = function () {
         this.clearCache();
-        this._user = null;
         var urlNavigate;
 
         if (this.config.logOutUri) {
@@ -924,7 +928,8 @@ var AuthenticationContext = (function () {
      * @ignore
      */
     AuthenticationContext.prototype._addHintParameters = function (urlNavigate) {
-        //If you don�t use prompt=none, then if the session does not exist, there will be a failure.
+
+        //If you don't use prompt=none, then if the session does not exist, there will be a failure.
         //If sid is sent alongside domain or login hints, there will be a failure since request is ambiguous.
         //If sid is sent with a prompt value other than none or attempt_none, there will be a failure since the request is ambiguous.
 
@@ -1089,9 +1094,9 @@ var AuthenticationContext = (function () {
     };
 
     /**
-     * Matches nonce from the request with the response.
-     * @ignore
-     */
+    * Matches nonce from the request with the response.
+    * @ignore
+    */
     AuthenticationContext.prototype._matchNonce = function (user) {
         var requestNonce = this._getItem(this.CONSTANTS.STORAGE.NONCE_IDTOKEN);
 
@@ -1108,9 +1113,9 @@ var AuthenticationContext = (function () {
     };
 
     /**
-     * Matches state from the request with the response.
-     * @ignore
-     */
+    * Matches state from the request with the response.
+    * @ignore
+    */
     AuthenticationContext.prototype._matchState = function (requestInfo) {
         var loginStates = this._getItem(this.CONSTANTS.STORAGE.STATE_LOGIN);
 
@@ -1213,17 +1218,16 @@ var AuthenticationContext = (function () {
                             this._user = null;
                         } else {
                             this._saveItem(this.CONSTANTS.STORAGE.IDTOKEN, requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
-
                             // Save idtoken as access token for app itself
-                            resource = this.config.loginResource ? this.config.loginResource : this.config.clientId;
+                            var idTokenResource = this.config.loginResource ? this.config.loginResource : this.config.clientId;
 
-                            if (!this._hasResource(resource)) {
+                            if (!this._hasResource(idTokenResource)) {
                                 keys = this._getItem(this.CONSTANTS.STORAGE.TOKEN_KEYS) || '';
-                                this._saveItem(this.CONSTANTS.STORAGE.TOKEN_KEYS, keys + resource + this.CONSTANTS.RESOURCE_DELIMETER);
+                                this._saveItem(this.CONSTANTS.STORAGE.TOKEN_KEYS, keys + idTokenResource + this.CONSTANTS.RESOURCE_DELIMETER);
                             }
 
-                            this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + resource, requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
-                            this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + resource, this._user.profile.exp);
+                            this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + idTokenResource, requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
+                            this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + idTokenResource, this._user.profile.exp);
                         }
                     }
                     else {
@@ -1279,7 +1283,7 @@ var AuthenticationContext = (function () {
         }
         else {
             // in angular level, the url for $http interceptor call could be relative url,
-            // if it's relative call, we'll treat it as app backend call.
+            // if it's relative call, we'll treat it as app backend call.            
             return this.config.loginResource;
         }
 
@@ -1429,7 +1433,7 @@ var AuthenticationContext = (function () {
         }
     };
 
-    //Take https://cdnjs.cloudflare.com/ajax/libs/Base64/0.3.0/base64.js and https://en.wikipedia.org/wiki/Base64 as reference.
+    //Take https://cdnjs.cloudflare.com/ajax/libs/Base64/0.3.0/base64.js and https://en.wikipedia.org/wiki/Base64 as reference. 
     AuthenticationContext.prototype._decode = function (base64IdToken) {
         var codes = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
         base64IdToken = String(base64IdToken).replace(/=+$/, '');
@@ -1685,7 +1689,7 @@ var AuthenticationContext = (function () {
                 ifr.setAttribute('aria-hidden', 'true');
                 ifr.style.visibility = 'hidden';
                 ifr.style.position = 'absolute';
-                ifr.style.width = ifr.style.height = ifr.borderWidth = '0px';
+                ifr.style.width = ifr.style.height = ifr.style.borderWidth = '0px';
 
                 adalFrame = document.getElementsByTagName('body')[0].appendChild(ifr);
             }
@@ -1760,20 +1764,44 @@ var AuthenticationContext = (function () {
     };
 
     /**
+     * Returns true if the browser supports given storage type
+     * @ignore
+     */
+    AuthenticationContext.prototype._supportsStorage = function(storageType) {
+        if (!(storageType in this._storageSupport)) {
+            return false;
+        }
+
+        if (this._storageSupport[storageType] !== null) {
+            return this._storageSupport[storageType];
+        }
+
+        try {
+            if (!(storageType in window) || window[storageType] === null) {
+                throw new Error();
+            }
+            var testKey = '__storageTest__';
+            window[storageType].setItem(testKey, 'A');
+            if (window[storageType].getItem(testKey) !== 'A') {
+                throw new Error();
+            }
+            window[storageType].removeItem(testKey);
+            if (window[storageType].getItem(testKey)) {
+                throw new Error();
+            }
+            this._storageSupport[storageType] = true;
+        } catch (e) {
+            this._storageSupport[storageType] = false;
+        }
+        return this._storageSupport[storageType];
+    }
+
+    /**
      * Returns true if browser supports localStorage, false otherwise.
      * @ignore
      */
-    AuthenticationContext.prototype._supportsLocalStorage = function () {
-        try {
-            if (!window.localStorage) return false; // Test availability
-            window.localStorage.setItem('storageTest', 'A'); // Try write
-            if (window.localStorage.getItem('storageTest') != 'A') return false; // Test read/write
-            window.localStorage.removeItem('storageTest'); // Try delete
-            if (window.localStorage.getItem('storageTest')) return false; // Test delete
-            return true; // Success
-        } catch (e) {
-            return false;
-        }
+    AuthenticationContext.prototype._supportsLocalStorage = function () {        
+        return this._supportsStorage('localStorage');
     };
 
     /**
@@ -1781,16 +1809,7 @@ var AuthenticationContext = (function () {
      * @ignore
      */
     AuthenticationContext.prototype._supportsSessionStorage = function () {
-        try {
-            if (!window.sessionStorage) return false; // Test availability
-            window.sessionStorage.setItem('storageTest', 'A'); // Try write
-            if (window.sessionStorage.getItem('storageTest') != 'A') return false; // Test read/write
-            window.sessionStorage.removeItem('storageTest'); // Try delete
-            if (window.sessionStorage.getItem('storageTest')) return false; // Test delete
-            return true; // Success
-        } catch (e) {
-            return false;
-        }
+        return this._supportsStorage('sessionStorage');
     };
 
     /**
@@ -1822,7 +1841,7 @@ var AuthenticationContext = (function () {
     };
 
     /**
-     * Checks the Logging Level, constructs the Log message and logs it. Users need to implement/override this method to turn on Logging.
+     * Checks the Logging Level, constructs the Log message and logs it. Users need to implement/override this method to turn on Logging. 
      * @param {number} level  -  Level can be set 0,1,2 and 3 which turns on 'error', 'warning', 'info' or 'verbose' level logging respectively.
      * @param {string} message  -  Message to log.
      * @param {string} error  -  Error to log.
@@ -1884,10 +1903,10 @@ var AuthenticationContext = (function () {
     };
 
     /**
-     * Logs Pii messages when Logging Level is set to 0 and window.piiLoggingEnabled is set to true.
-     * @param {string} message  -  Message to log.
-     * @param {string} error  -  Error to log.
-     */
+    * Logs Pii messages when Logging Level is set to 0 and window.piiLoggingEnabled is set to true.
+    * @param {string} message  -  Message to log.
+    * @param {string} error  -  Error to log.
+    */
     AuthenticationContext.prototype.errorPii = function (message, error) {
         this.log(this.CONSTANTS.LOGGING_LEVEL.ERROR, message, error, true);
     };
@@ -1920,7 +1939,7 @@ var AuthenticationContext = (function () {
      * @ignore
      */
     AuthenticationContext.prototype._libVersion = function () {
-        return '1.0.17';
+        return '1.0.18';
     };
 
     /**

--- a/src/react-adal.js
+++ b/src/react-adal.js
@@ -18,7 +18,7 @@ function shouldAcquireNewToken(message) {
 }
 
 function parseResourceInfo(resourceInfo) {
-  typeof resourceInfo === 'string' ? { resourceGuiId: resourceInfo } : resourceInfo;
+  return typeof resourceInfo === 'string' ? { resourceGuiId: resourceInfo } : resourceInfo;
 }
 
 export function adalGetToken(authContext, resourceInfo, callback) {

--- a/src/react-adal.js
+++ b/src/react-adal.js
@@ -58,8 +58,10 @@ export function runWithAdal(authContext, app, doNotLogin) {
   //prevent iframe double app !!!
   if (window === window.parent) {
     if (!authContext.isCallback(window.location.hash)) {
-      if (!authContext.getCachedToken(authContext.config.clientId)
-          || !authContext.getCachedUser()) {
+      const resource = authContext.config.loginResource; // adal sdk assigns clientId if loginResource is not provided
+      const token = authContext.getCachedToken(resource);
+      const user = authContext.getCachedUser();
+      if (!token || !user) {
         if (doNotLogin) {
           app();
         } else {


### PR DESCRIPTION
Hi, the proposed PR includes the following features/fixes:

1. **Adal SDK update to latest** (1.0.18). Furthermore, I included a simple script to automatically fetch latest from github and clone it in our code.

2. **Allow extra parameters while fetching token**. This is to comply with SDK's `acquireTokenRedirect` and `acquireTokenPopup` signatures (with the latter being broken before the fix).

3. **Using `loginResource` to check login token** instead of `clientId`. This because SDK's AuthenticationContext constructor already handles missing `loginResource` by value it as `clientId`. Thus it can now cover both scenario: with both `loginResource` and `clientId` and only `clientId` provided.

I hope you'll appreciate the PR. Please let's discuss it to improve.

Thanks
