### PR TITLE
Null-check for endpoints

### DIFF
--- a/src/adal.mod.js
+++ b/src/adal.mod.js
@@ -4,6 +4,7 @@ import AuthenticationContext from './adal';
  * Validates each resource token in cache againt current user
  */
 AuthenticationContext.prototype.invalidateResourceTokens = function () {
+  if (!this.config.endpoints) { return; }
   const idToken = this._getItem(this.CONSTANTS.STORAGE.IDTOKEN);
   if (!idToken) { return; }
   const { upn } = this._extractIdToken(idToken);


### PR DESCRIPTION
Since the endpoints parameter can still be omitted in the original implementation of the adal lib ([based on this condition](https://github.com/salvoravida/react-adal/blob/1cd160998b703397ac46cd12fb5bef965254b2b3/src/adal.js#L1267)) to support some scenarios, I think it would be reasonable to check it for null in the in recently added [invalidateResourceTokens](https://github.com/salvoravida/react-adal/blob/1cd160998b703397ac46cd12fb5bef965254b2b3/src/adal.mod.js#L6) method as well. Otherwise, we could get an error on this [line](https://github.com/salvoravida/react-adal/blob/1cd160998b703397ac46cd12fb5bef965254b2b3/src/adal.mod.js#L10).