### PR TITLE
Case-insensitivity of UPNs

### DIFF
--- a/src/adal.mod.js
+++ b/src/adal.mod.js
@@ -21,7 +21,7 @@ AuthenticationContext.prototype._clearStaleResourceToken = function (resource, c
   const resourceToken = this.getCachedToken(resource);
   if (resourceToken) {
     const { upn } = this._extractIdToken(resourceToken);
-    if (upn !== currentUserUpn) {
+    if (upn.toLowerCase() !== currentUserUpn.toLowerCase()) {
       this.info(`Clearing invalid cache of resource ${resource}`);
       this.clearCacheForResource(resource);
     }


### PR DESCRIPTION
Requesting the access token leads to an endless loop, if UPNs have case. This code change fixes the problem.